### PR TITLE
Fix permit transactions params, set version 1.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vostokplatform/waves-api",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "Vostok client-side API library",
   "keywords": [
     "cryptocurrency",

--- a/src/api/node/transactions.x.ts
+++ b/src/api/node/transactions.x.ts
@@ -568,10 +568,10 @@ export const postPermit = createRemapper({
     version: constants.PERMISSION_TX_VERSION
 });
 
-export const sendPermissionTx = wrapTxRequest(TX_TYPE_MAP.sponsorship, preSponsorship, postSponsorship, (postParams: any) => {
+export const sendPermissionTx = wrapTxRequest(TX_TYPE_MAP.permit, prePermit, postPermit, (postParams: any) => {
     return fetch(constants.BROADCAST_PATH, postParams);
 }, true) as TTransactionRequest;
 
-export const sendSignedPermissionTx = wrapTxRequest(TX_TYPE_MAP.sponsorship, preSponsorship, postSponsorship, (postParams: any) => {
+export const sendSignedPermissionTx = wrapTxRequest(TX_TYPE_MAP.permit, prePermit, postPermit, (postParams: any) => {
     return getSignedTx(postParams).data;
 }, true) as TTransactionRequest;


### PR DESCRIPTION
При создании permit транзакции в функцию sendSignedPermissionTx передавались параметры для другого типа транзакции (sponsorship)