### PR TITLE
Add Contracts GET methods

### DIFF
--- a/src/api/node/addresses.ts
+++ b/src/api/node/addresses.ts
@@ -16,6 +16,10 @@ export default {
 
     balanceDetails(address: string) {
         return fetch(`/addresses/balance/details/${address}`);
+    },
+
+    data(address: string) {
+        return fetch(`/addresses/data/${address}`)
     }
 
 };

--- a/src/api/node/addresses.ts
+++ b/src/api/node/addresses.ts
@@ -1,5 +1,5 @@
 import { createFetchWrapper, PRODUCTS, VERSIONS, processJSON } from '../../utils/request';
-
+import {DEFAULT_PAGING_OFFSET, DEFAULT_PAGING_LIMIT} from '../../constants';
 
 const fetch = createFetchWrapper(PRODUCTS.NODE, VERSIONS.V1, processJSON);
 
@@ -18,15 +18,8 @@ export default {
         return fetch(`/addresses/balance/details/${address}`);
     },
 
-    data(address: string, offset?: number, limit?: number) {
-        let params = '';
-        if (typeof offset !== 'undefined') {
-            params += `&offset=${offset}`
-        }
-        if (typeof limit !== 'undefined') {
-            params += `&limit=${limit}`
-        }
-        return fetch(`/addresses/data/${address}${params}`)
+    data(address: string, offset: number = DEFAULT_PAGING_OFFSET, limit: number = DEFAULT_PAGING_LIMIT) {
+        return fetch(`/addresses/data/${address}?offset=${offset}&limit=${limit}`);
     }
 
 };

--- a/src/api/node/addresses.ts
+++ b/src/api/node/addresses.ts
@@ -18,8 +18,15 @@ export default {
         return fetch(`/addresses/balance/details/${address}`);
     },
 
-    data(address: string) {
-        return fetch(`/addresses/data/${address}`)
+    data(address: string, offset?: number, limit?: number) {
+        let params = '';
+        if (typeof offset !== 'undefined') {
+            params += `&offset=${offset}`
+        }
+        if (typeof limit !== 'undefined') {
+            params += `&limit=${limit}`
+        }
+        return fetch(`/addresses/data/${address}${params}`)
     }
 
 };

--- a/src/api/node/contracts.ts
+++ b/src/api/node/contracts.ts
@@ -6,8 +6,15 @@ const fetch = createFetchWrapper(PRODUCTS.NODE, VERSIONS.V1, processJSON);
 
 export default {
 
-    get(id: string) {
-        return fetch(`/contracts/${id}`);
+    get(id: string, offset?: number, limit?: number) {
+        let params = '';
+        if (typeof offset !== 'undefined') {
+            params += `&offset=${offset}`
+        }
+        if (typeof limit !== 'undefined') {
+            params += `&limit=${limit}`
+        }
+        return fetch(`/contracts/${id}${params}`);
     },
 
     getKey(id: string, key: string) {

--- a/src/api/node/contracts.ts
+++ b/src/api/node/contracts.ts
@@ -1,20 +1,13 @@
 import { createFetchWrapper, PRODUCTS, VERSIONS, processJSON } from '../../utils/request';
-
+import {DEFAULT_PAGING_OFFSET, DEFAULT_PAGING_LIMIT} from '../../constants';
 
 const fetch = createFetchWrapper(PRODUCTS.NODE, VERSIONS.V1, processJSON);
 
 
 export default {
 
-    get(id: string, offset?: number, limit?: number) {
-        let params = '';
-        if (typeof offset !== 'undefined') {
-            params += `&offset=${offset}`
-        }
-        if (typeof limit !== 'undefined') {
-            params += `&limit=${limit}`
-        }
-        return fetch(`/contracts/${id}${params}`);
+    get(id: string, offset: number = DEFAULT_PAGING_OFFSET, limit: number = DEFAULT_PAGING_LIMIT) {
+        return fetch(`/contracts/${id}?offset=${offset}&limit=${limit}`);
     },
 
     getKey(id: string, key: string) {

--- a/src/api/node/contracts.ts
+++ b/src/api/node/contracts.ts
@@ -1,0 +1,21 @@
+import { createFetchWrapper, PRODUCTS, VERSIONS, processJSON } from '../../utils/request';
+
+
+const fetch = createFetchWrapper(PRODUCTS.NODE, VERSIONS.V1, processJSON);
+
+
+export default {
+
+    get(id: string) {
+        return fetch(`/contracts/${id}`);
+    },
+
+    getKey(id: string, key: string) {
+        return fetch(`/contracts/${id}/${key}`);
+    },
+
+    getExecutedTxFor(id: string) {
+        return fetch(`/contracts/executed-tx-for/${id}`);
+    }
+
+};

--- a/src/api/node/index.ts
+++ b/src/api/node/index.ts
@@ -14,6 +14,7 @@ export interface INodeAPI {
     addresses: {
         balance(address: string, confirmations?: number): Promise<any>;
         balanceDetails(address: string): Promise<any>;
+        data(address: string): Promise<any>;
     },
     aliases: {
         byAlias(alias: string): Promise<any>;

--- a/src/api/node/index.ts
+++ b/src/api/node/index.ts
@@ -14,7 +14,7 @@ export interface INodeAPI {
     addresses: {
         balance(address: string, confirmations?: number): Promise<any>;
         balanceDetails(address: string): Promise<any>;
-        data(address: string): Promise<any>;
+        data(address: string, offset?: number, limit?: number): Promise<any>;
     },
     aliases: {
         byAlias(alias: string): Promise<any>;
@@ -33,7 +33,7 @@ export interface INodeAPI {
         height(): Promise<any>;
     },
     contracts: {
-        get(id: string): Promise<any>;
+        get(id: string, offset?: number, limit?: number): Promise<any>;
         getKey(id: string, key: string): Promise<any>;
         getExecutedTxFor(id: string): Promise<any>;
     },

--- a/src/api/node/index.ts
+++ b/src/api/node/index.ts
@@ -4,6 +4,7 @@ import Addresses from './addresses';
 import Aliases from './aliases';
 import Assets from './assets';
 import Blocks from './blocks';
+import Contracts from './contracts'
 import Leasing from './leasing';
 import Transactions from './transactions';
 import Utils from './utils';
@@ -30,6 +31,11 @@ export interface INodeAPI {
         last(): Promise<any>;
         height(): Promise<any>;
     },
+    contracts: {
+        get(id: string): Promise<any>;
+        getKey(id: string, key: string): Promise<any>;
+        getExecutedTxFor(id: string): Promise<any>;
+    },
     leasing: {
         getAllActiveLeases(address: string): Promise<any>;
     },
@@ -53,6 +59,7 @@ export const addresses = Addresses;
 export const aliases = Aliases;
 export const assets = Assets;
 export const blocks = Blocks;
+export const contracts = Contracts;
 export const leasing = Leasing;
 export const transactions = Transactions;
 export const utils = Utils;

--- a/src/api/node/index.ts
+++ b/src/api/node/index.ts
@@ -14,7 +14,7 @@ export interface INodeAPI {
     addresses: {
         balance(address: string, confirmations?: number): Promise<any>;
         balanceDetails(address: string): Promise<any>;
-        data(address: string, offset?: number, limit?: number): Promise<any>;
+        data(address: string, offset: number, limit: number): Promise<any>;
     },
     aliases: {
         byAlias(alias: string): Promise<any>;
@@ -33,7 +33,7 @@ export interface INodeAPI {
         height(): Promise<any>;
     },
     contracts: {
-        get(id: string, offset?: number, limit?: number): Promise<any>;
+        get(id: string, offset: number, limit: number): Promise<any>;
         getKey(id: string, key: string): Promise<any>;
         getExecutedTxFor(id: string): Promise<any>;
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,6 +71,9 @@ export const DEFAULT_MIN_SEED_LENGTH = 25;
 
 export const DEFAULT_ORDER_EXPIRATION_DAYS = 20;
 
+export const DEFAULT_PAGING_LIMIT = 50;
+export const DEFAULT_PAGING_OFFSET = 0;
+
 export const DEFAULT_BASIC_CONFIG: IWavesBasicConfig = {
     minimumSeedLength: DEFAULT_MIN_SEED_LENGTH,
     requestOffset: 0,


### PR DESCRIPTION
+ добавлены обертки для Contracts GET запросов:
/contracts/${id}
/contracts/${id}/${key}
/contracts/executed-tx-for/${id}

и для данных на адресе:
/addresses/data/${address}

+ добавлены опциональные параметры limit и offset для запросов стейта (контракта и адреса)